### PR TITLE
Only one ConsoleHandler is added to the logger

### DIFF
--- a/server/FDDG-server/src/nl/tud/dcs/fddg/client/ClientProcess.java
+++ b/server/FDDG-server/src/nl/tud/dcs/fddg/client/ClientProcess.java
@@ -43,9 +43,12 @@ public class ClientProcess extends UnicastRemoteObject implements nl.tud.dcs.fdd
         this.logger = Logger.getLogger(ClientProcess.class.getName());
         logger.setLevel(Level.INFO);
         logger.setUseParentHandlers(false);
-        Handler consoleHandler = new ConsoleHandler();
-        consoleHandler.setLevel(Level.ALL);
-        logger.addHandler(consoleHandler);
+
+        if(logger.getHandlers().length == 0) {
+            Handler consoleHandler = new ConsoleHandler();
+            consoleHandler.setLevel(Level.ALL);
+            logger.addHandler(consoleHandler);
+        }
 
         this.messagesFromServer = 0;
         this.messagesToServer = 0;
@@ -214,7 +217,7 @@ public class ClientProcess extends UnicastRemoteObject implements nl.tud.dcs.fdd
             Random random = new Random();
             int randomServerId = random.nextInt(serverURLs.length);
             try {
-                logger.info("Client " + ID + " trying to connect to " + serverURLs[randomServerId]);
+                logger.info("Client trying to connect to " + serverURLs[randomServerId]);
                 server = (ClientServerInterface) Naming.lookup(serverURLs[randomServerId]);
                 if(shouldReconnect) {
                     String clientName = "//" + InetAddress.getLocalHost().getHostAddress() + ":1099/FDDGClient/" + ID;


### PR DESCRIPTION
Now, only one ConsoleHandler is added to the logger instead of one for each new clients. In this way all log messages are only printed once
